### PR TITLE
[Trivial] fix a typo in message after cluster creation

### DIFF
--- a/ltcli/redistrib2/command.py
+++ b/ltcli/redistrib2/command.py
@@ -139,7 +139,7 @@ def create(host_port_list, max_slots=1024):
                              max_slots)
             sleep(0.02)
             logging.info('Add %d slots to %s:%d', slots_each, t.host, t.port)
-        msg = message.get('check_cluster_state_asign_slot')
+        msg = message.get('check_cluster_state_assign_slot')
         logger.info(msg)
         for t in conns:
             _poll_check_status(t)

--- a/ltcli/string.json
+++ b/ltcli/string.json
@@ -149,7 +149,7 @@
     "save_config_to_template": "Save config to template...",
     "cluster_meet": "Cluster meet...",
     "adding_slot": "Adding slots...",
-    "check_cluster_state_asign_slot": "Check cluster state and asign slot...",
+    "check_cluster_state_assign_slot": "Check cluster state and assign slot...",
     "try_connection": "Connecting...",
     "loading_dataset": "LOADING Redis is loading the dataset in memory.",
     "apply_after_restart": "Applies after restart."


### PR DESCRIPTION

(related #11) fix a typo in the message after `cluster create`

**before:**
`Check cluster state and asign slot...`

**after:**
`Check cluster state and assign slot...`